### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fixturator.generate!
 # Uses the config/fixturator.yml
 # generates a bunch of fixtures in your configured fixture directory
 
-Fixturator.call(User, exclude_attributes: ["created_at"])
+Fixturator.call(User, excluded_attributes: ["created_at"])
 # generates a User fixture at your configured fixture directory
 # by default it's at test/fixtures/users.yml
 ```


### PR DESCRIPTION
Change "exclude_attributes" to "excluded_attributes" in the Usage
section of the readme. Fixturator::Generator is initialized with
"excluded_attributes", so the usage example will lead to an error!